### PR TITLE
Alternative Socket handover mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ in the [KDE wiki](https://invent.kde.org/plasma/kwin/-/wikis/Restarting).
 - Don't lose your session (for programs that support seamless Wayland reconnect)
 - Configurable max number of crashes before giving up
 - Sets `WL_RESTART_COUNT` to the current restart counter on compositor restart.
-- Support for two different experimental socket handover mechanisms
+- Support for four different experimental socket handover mechanisms
   - `--kde`: `--socket` and `--wayland-fd`
+  - `--cli`: `--wayland-socket` and `--wayland-fd`
   - `--env`: `WAYLAND_SOCKET_NAME` and `WAYLAND_SOCKET_FD`
+  - `--systemd`: [systemd socket activation](https://man.archlinux.org/man/sd_listen_fds.3.en) via `LISTEN_PID`, `LISTEN_FDS`, and `LISTEN_FDNAMES`
 
 ## Usage
 
@@ -60,7 +62,9 @@ options:
   -h,   --help           show this help
   -n N, --max-restarts N restart a maximum of N times (default 10)
         --kde            pass socket via cli options --socket and --wayland-fd (default)
+        --cli            pass socket via cli options --wayland-socket and --wayland-fd
         --env            pass socket via env vars WAYLAND_SOCKET_NAME and WAYLAND_SOCKET_FD
+        --systemd        pass socket via env vars LISTEN_PID, LISTEN_FDS, and LISTEN_FDNAMES
 ```
 
 For example, run this in your TTY instead of normally starting your compositor:

--- a/man/wl-restart.1.scd
+++ b/man/wl-restart.1.scd
@@ -49,8 +49,21 @@ details, see *CLIENT AND TOOLKIT SUPPORT* below.
 	Pass socket via cli options --socket and --wayland-fd. (default)
 	This passes the socket in the same form as KDE's *kwin_wayland_wrapper*.
 
+*--cli*
+	Pass socket via cli options --wayland-socket and --wayland-fd.
+
 *--env*
 	Pass socket via env vars WAYLAND_SOCKET_NAME and WAYLAND_SOCKET_FD.
+
+*--systemd*
+	Pass socket via env vars LISTEN_PID, LISTEN_FDS, and LISTEN_FDNAMES.
+	This passes the socket in the same form as the systemd socket activation
+	protocol. Further information can be found in *sd_listen_fds*(3).
+
+	The only difference from regular systemd socket activation is that in this
+	case *wl-restart* will have already created the Wayland socket lock file,
+	which would not be created by regular systemd socket activation as it is
+	Wayland-specific.
 
 # BEHAVIOUR
 


### PR DESCRIPTION
This PR implements the alternative CLI-based and environment-based socket handover mechanisms outlined in #2.

This PR is an extension of #4.

List of supported socket handover mechanisms after this PR:
- `--kde`: The KDE socket handover mechanism. Socket passed via `--socket` and `--wayland-fd`
- `--cli`: The alternative CLI socket handover mechanism: Socket passed via `--wayland-socket` and `--wayland-fd` (*new*)
- `--env`: An environment-based socket handover mechanism: Socket passed via `WAYLAND_SOCKET_NAME` and `WAYLAND_SOCKET_FD`.
- `--systemd`: The systemd socket activation handover mechanism: Socket passed via  `LISTEN_PID`, `LISTEN_FDS`, and `LISTEN_FDNAMES` (*new*)

Testing and evaluation of the different mechanisms should be performed before this is merged, though I can see wl-restart supporting multiple of these or even all four mechanisms.