### PR TITLE
Environment-based Socket Handover Mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ the compositor with the options `--socket NAME --wayland-fd FD`.
 **Supported Compositors:**
 
 - Kwin (but you should probably use `kwin_wayland_wrapper` instead, which is default in Plasma 6)
+- Hyprland
 - Sway (via [`feature-socket-handover`](https://github.com/ferdi265/sway/tree/feature-socket-handover) branch)
-- Hyprland (merged in git, but not released yet)
+- labwc (via [`feature-socket-handover`](https://github.com/ferdi265/labwc/tree/feature-socket-handover) branch)
 
 Other compositors do not support Wayland socket handover as of now. If there are
 any compositors with support for socket handover missing from this list, please
@@ -43,6 +44,9 @@ in the [KDE wiki](https://invent.kde.org/plasma/kwin/-/wikis/Restarting).
 - Don't lose your session (for programs that support seamless Wayland reconnect)
 - Configurable max number of crashes before giving up
 - Sets `WL_RESTART_COUNT` to the current restart counter on compositor restart.
+- Support for two different experimental socket handover mechanisms
+  - `--kde`: `--socket` and `--wayland-fd`
+  - `--env`: `WAYLAND_SOCKET_NAME` and `WAYLAND_SOCKET_FD`
 
 ## Usage
 
@@ -53,8 +57,10 @@ compositor restart helper. restarts your compositor when it
 crashes and keeps the wayland socket alive.
 
 options:
-  -h,   --help             show this help
-  -n N, --max-restarts N   restart a maximum of N times (default 10)
+  -h,   --help           show this help
+  -n N, --max-restarts N restart a maximum of N times (default 10)
+        --kde            pass socket via cli options --socket and --wayland-fd (default)
+        --env            pass socket via env vars WAYLAND_SOCKET_NAME and WAYLAND_SOCKET_FD
 ```
 
 For example, run this in your TTY instead of normally starting your compositor:

--- a/man/wl-restart.1.scd
+++ b/man/wl-restart.1.scd
@@ -28,9 +28,10 @@ Example Usage:
 	$ wl-restart -n 7 hyprland
 
 This only works for compositors that support Wayland socket handover and that
-support the *--socket* and *--wayland-fd* options. Currently that is only Kwin,
-but patches exist for sway and hyprland. For details, see *COMPOSITOR SUPPORT*
-below.
+support the *--socket* and *--wayland-fd* options or any of the other socket
+handover mechanisms detailed under *OPTIONS*. Currently that is only Kwin and
+Hyprland, but patches exist for sway and labwc. For details, see *COMPOSITOR
+SUPPORT* below.
 
 Currently there aren't many clients and toolkits that support surviving a
 compositor restart, with *Qt6* and the KDE apps being a notable exception. For
@@ -43,6 +44,13 @@ details, see *CLIENT AND TOOLKIT SUPPORT* below.
 
 *-n N, --max-restarts N*
 	Restart the compositor a maximum of *N* times. (default is 10)
+
+*--kde*
+	Pass socket via cli options --socket and --wayland-fd. (default)
+	This passes the socket in the same form as KDE's *kwin_wayland_wrapper*.
+
+*--env*
+	Pass socket via env vars WAYLAND_SOCKET_NAME and WAYLAND_SOCKET_FD.
 
 # BEHAVIOUR
 
@@ -85,14 +93,28 @@ the *--socket* and *--wayland-fd* options.
 	by *kwin_wayland_wrapper*, which is automatically used in
 	*startplasma_wayland*.
 
+	Kwin uses the *KDE* socket handover mechanism.
+
+*hyprland*
+	Hyprland Git supports socket handover and works well with *wl-restart*.
+
+	Hyprland uses the *KDE* socket handover mechanism.
+
 *sway*
 	Upstream Sway does not support socket handover, but socket handover is
 	implemented in the following branch and works well with *wl-restart*:
 
 	https://github.com/ferdi265/sway/tree/feature-socket-handover
 
-*hyprland*
-	Hyprland Git supports socket handover and works well with *wl-restart*.
+	This branch uses the *KDE* socket handover mechanism.
+
+*labwc*
+	Upstream labwc does not support socket handover, but socket handover is
+	implemented in the following branch and works with *wl-restart*:
+
+	https://github.com/ferdi265/labwc/tree/feature-socket-handover
+
+	This branch uses the *env var* socket handover mechanism.
 
 Other compositors do not support Wayland socket handover as of now. If there are
 any compositors with support for socket handover missing from this list, please


### PR DESCRIPTION
This PR implements the environment-based socket handover mechanism with custom environment variables outlined in #2 and makes it available with the `--env` option to `wl-restart`. The existing behaviour is still the default and can explicitly be specified with `--kde`.

List of supported socket handover mechanisms after this PR:
- `--kde`: The KDE socket handover mechanism. Socket passed via `--socket` and `--wayland-fd`
- `--env`: An environment-based socket handover mechanism: Socket passed via `WAYLAND_SOCKET_NAME` and `WAYLAND_SOCKET_FD`. (*new*)

## Compositor Implementation

A compositor should either automatically use the socket provided in  the `WAYLAND_SOCKET_NAME` and `WAYLAND_SOCKET_FD` environment variables or use them when passed a specific option (e.g. `--wayland-socket-handover`). This option need not be standardized as users can pass it to `wl-restart` manually for compositors that don't want to include this behaviour by default (e.g. `wl-restart --env my-compositor --wayland-socket-handover`).

A supporting compositor should unset these variables in its environment after reading them and set `FD_CLOEXEC` on the file descriptor to ensure the environment of the session isn't polluted.

## Future Work

- Specify protocol more rigorously
- Incorporate feedback from compositor implementors